### PR TITLE
[ci skip] adding user @izahn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @izahn @jerowe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,3 +51,4 @@ about:
 extra:
   recipe-maintainers:
     - jerowe 
+    - izahn


### PR DESCRIPTION
@conda-forge/core The bot was unable to open a PR adding me as a maintainer in https://github.com/conda-forge/lmod-feedstock/issues/31 so I've done it manually here. 

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has [ci skip] in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.